### PR TITLE
Use SPDX license identifier

### DIFF
--- a/data-sketches/data-sketches.cabal
+++ b/data-sketches/data-sketches.cabal
@@ -12,7 +12,7 @@ bug-reports:    https://github.com/iand675/datasketches-haskell/issues
 author:         Ian Duncan, Rob Bassi
 maintainer:     ian@iankduncan.com
 copyright:      2021 Ian Duncan, Rob Bassi, Mercury Technologies
-license:        Apache
+license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:


### PR DESCRIPTION
Lack of a SPDX compliant identifier causes some minor noise when using with haskell.nix