### PR TITLE
fix: Use SPDX-compliant license

### DIFF
--- a/data-sketches/data-sketches.cabal
+++ b/data-sketches/data-sketches.cabal
@@ -12,7 +12,7 @@ bug-reports:    https://github.com/iand675/datasketches-haskell/issues
 author:         Ian Duncan, Rob Bassi
 maintainer:     ian@iankduncan.com
 copyright:      2021 Ian Duncan, Rob Bassi, Mercury Technologies
-license:        Apache
+license:        Apache-2.0
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:


### PR DESCRIPTION
I checked the [spdx identifier list](https://spdx.org/licenses/) and it seems that adding the `-2.0` suffix makes this compliant.

This fixes an annoying warning printed in the bowels of our haskell.nix infrastructure.