### PR TITLE
add header files as extra sources to fix compilation failure

### DIFF
--- a/data-sketches-core/ChangeLog.md
+++ b/data-sketches-core/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for data-sketches-core
 
+
+## 0.2.0.1
+
+### Bug fixes
+
+- **Missing header files**: Add C header files to extra-source-files
+  to fix compilation failure.
+
 ## 0.2.0.0
 
 ### New sketch families

--- a/data-sketches-core/data-sketches-core.cabal
+++ b/data-sketches-core/data-sketches-core.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           data-sketches-core
-version:        0.2.0.0
+version:        0.2.0.1
 description:    Please see the README on GitHub at <https://github.com/iand675/datasketches-haskell#readme>
 homepage:       https://github.com/iand675/datasketches-haskell#readme
 bug-reports:    https://github.com/iand675/datasketches-haskell/issues
@@ -18,6 +18,8 @@ build-type:     Simple
 extra-source-files:
     README.md
     ChangeLog.md
+    cbits/req.h
+    cbits/kll.h
 
 source-repository head
   type: git
@@ -53,6 +55,8 @@ library
       TypeFamilies
       TypeOperators
   cc-options: -O2
+  include-dirs:
+      cbits
   c-sources:
       cbits/sketches.c
       cbits/kll.c

--- a/data-sketches-core/package.yaml
+++ b/data-sketches-core/package.yaml
@@ -1,5 +1,5 @@
 name:                data-sketches-core
-version:             0.2.0.0
+version:             0.2.0.1
 github:              "iand675/datasketches-haskell"
 license:             BSD3
 author:              "Ian Duncan"
@@ -18,6 +18,8 @@ default-extensions:
 extra-source-files:
 - README.md
 - ChangeLog.md
+- cbits/req.h
+- cbits/kll.h
 
 # Metadata used when publishing your package
 # synopsis:            Short description of your package
@@ -46,6 +48,8 @@ library:
   - cbits/countmin.c
   - cbits/theta.c
   - cbits/req.c
+  include-dirs:
+  - cbits
   cc-options:
   - -O2
   exposed-modules:


### PR DESCRIPTION
When building `data-sketches-core` with cabal-install 3.14.2.0 and GHC 9.6.6 as a dependency, compilation fails for me with an error from GCC, saying it could not find `req.h`. 

We add clauses in the `package.yaml` and `*.cabal` files explicitly listing the header files as extra source files; this makes sure these files are copied over to the source dist directory and thereby fixes the problem.

Fixes https://github.com/iand675/datasketches-haskell/issues/5