### PR TITLE
fix(req): derive mkAuxiliary totals from compactors instead of erroring on stale cache

### DIFF
--- a/data-sketches-core/ChangeLog.md
+++ b/data-sketches-core/ChangeLog.md
@@ -1,5 +1,22 @@
 # Changelog for data-sketches-core
 
+## Unreleased
+
+### Bug fixes
+
+- **REQ: `invariant violated: lastWeight does not equal raSize` (#2)**:
+  `mkAuxiliary` previously trusted the sketch's cached `totalN` and
+  `retainedItems` and called `error` if they disagreed with the actual
+  compactor contents. An async exception delivered mid-`insert` (e.g. a
+  warp request handler being killed on client disconnect, while inside
+  `withMVar … insert`) can leave those cached counters skewed, after which
+  every subsequent `quantile` call would throw. `mkAuxiliary` now derives
+  both the retained-item count and the total weight directly from the
+  compactor buffers, so the auxiliary (and hence `quantile`) remains
+  self-consistent and never throws on this path. The `totalN` /
+  `retainedItems` parameters are retained for API compatibility but are
+  now ignored.
+
 ## 0.2.0.1
 
 ### Bug fixes

--- a/data-sketches-core/src/DataSketches/Quantiles/RelativeErrorQuantile/Internal/Auxiliary.hs
+++ b/data-sketches-core/src/DataSketches/Quantiles/RelativeErrorQuantile/Internal/Auxiliary.hs
@@ -41,24 +41,40 @@ data MReqAuxiliary s = MReqAuxiliary
   , mraSize :: {-# UNPACK #-} !Word64
   }
 
+-- | Build a sorted-view auxiliary from a vector of compactors.
+--
+-- The @totalN@ and @retainedItems@ arguments are accepted for API
+-- compatibility but are no longer trusted: both are recomputed from the
+-- compactor buffers themselves. This makes the auxiliary self-consistent
+-- even when the sketch's cached counters have drifted from the actual
+-- buffer contents (which can happen if an async exception interrupts
+-- 'insert' between its individual mutation steps — see issue #2).
+-- Previously this surfaced as @invariant violated: lastWeight does not
+-- equal raSize@; now the auxiliary simply reflects whatever is actually
+-- in the compactors.
 mkAuxiliary :: (PrimMonad m, s ~ PrimState m) => RankAccuracy -> Word64 -> Int -> Vector.Vector (ReqCompactor s) -> m ReqAuxiliary
-mkAuxiliary rankAccuracy totalN retainedItems compactors = do
+mkAuxiliary rankAccuracy _totalN _retainedItems compactors = do
+  retainedItems <- Vector.foldM countBuffer 0 compactors
   items <- newMutVar =<< MUVector.replicate retainedItems (0, 0)
   let this = MReqAuxiliary
         { mraWeightedItems = items
         , mraHighRankAccuracy = rankAccuracy
-        , mraSize = totalN
+        , mraSize = 0
         }
   Vector.foldM_ (mergeBuffers this) 0 compactors
-  createCumulativeWeights this
+  totalWeight <- createCumulativeWeights this
   dedup this
   items' <- U.unsafeFreeze =<< readMutVar items
   pure ReqAuxiliary
     { raWeightedItems = items'
     , raHighRankAccuracy = rankAccuracy
-    , raSize = totalN
+    , raSize = totalWeight
     }
   where
+    countBuffer acc compactor = do
+      buff <- Compactor.getBuffer compactor
+      buffSize <- DoubleBuffer.getCount buff
+      pure $! acc + buffSize
     mergeBuffers this auxCount compactor = do
       buff <- Compactor.getBuffer compactor
       buffSize <-  DoubleBuffer.getCount buff
@@ -92,7 +108,7 @@ getQuantile this normalRank ltEq = fst (weightedItems U.! ix)
     weightsSize = U.length weightedItems
     rank = floor (normalRank * fromIntegral (raSize this))
 
-createCumulativeWeights :: PrimMonad m => MReqAuxiliary (PrimState m) -> m ()
+createCumulativeWeights :: PrimMonad m => MReqAuxiliary (PrimState m) -> m Word64
 createCumulativeWeights this = do
   weights <- getWeights this
   let size = MUVector.length weights
@@ -101,9 +117,9 @@ createCumulativeWeights this = do
           prevWeight <- MUVector.read weights (i - 1)
           MUVector.unsafeWrite weights i (weight + prevWeight)
   forI_ weights (\i -> MUVector.read weights i >>= \x -> accumulateM i x)
-  lastWeight <- MUVector.read weights (size - 1)
-  when (lastWeight /= mraSize this) $ do
-    error "invariant violated: lastWeight does not equal raSize"
+  if size == 0
+    then pure 0
+    else MUVector.read weights (size - 1)
   where
     forI_ :: (Monad m, MG.MVector v a) => v (PrimState m) a -> (Int -> m b) -> m ()
     {-# INLINE forI_ #-}

--- a/data-sketches/data-sketches.cabal
+++ b/data-sketches/data-sketches.cabal
@@ -103,6 +103,7 @@ test-suite data-sketches-test
     , process
     , statistics
     , temporary
+    , text
     , vector
     , vector-algorithms
   default-language: Haskell2010

--- a/data-sketches/package.yaml
+++ b/data-sketches/package.yaml
@@ -65,6 +65,7 @@ tests:
     - data-sketches-core
     - hspec
     - hspec-junit-formatter
+    - text
     # - hspec-discover
     - QuickCheck
     - statistics

--- a/data-sketches/test/AuxiliarySpec.hs
+++ b/data-sketches/test/AuxiliarySpec.hs
@@ -8,12 +8,39 @@ import DataSketches.Quantiles.RelativeErrorQuantile.Types
 import Test.Hspec
 import qualified Data.Vector.Unboxed as U
 import qualified Data.List
+import qualified Data.Vector as Vector
 import DataSketches.Quantiles.RelativeErrorQuantile.Internal.DoubleBuffer
+import qualified DataSketches.Quantiles.RelativeErrorQuantile.Internal.Compactor as Compactor
+import System.Random.MWC (create)
 
 
 spec :: Spec
 spec = do
   mapM_ checkMergeSortIn [HighRanksAreAccurate, LowRanksAreAccurate]
+  describe "issue #2: invariant violated: lastWeight does not equal raSize" $ do
+    -- An async exception delivered mid-'insert' (e.g. from a warp request
+    -- handler being killed on client disconnect) can leave the sketch's
+    -- cached totalN / retainedItems out of sync with the actual compactor
+    -- buffer contents. mkAuxiliary must derive both from the compactors
+    -- rather than trusting the stale cache, so that quantile() keeps
+    -- working instead of throwing.
+    specify "mkAuxiliary tolerates stale totalN/retainedItems (derives from compactors)" $ do
+      g <- create
+      compactor <- Compactor.mkReqCompactor g 0 HighRanksAreAccurate 6
+      buff <- Compactor.getBuffer compactor
+      mapM_ (append buff) [1 .. 10 :: Double]
+      -- Pass deliberately wrong totalN (999) and retainedItems (3); the
+      -- old code would either 'error' on the invariant check or
+      -- unsafeWrite past the 3-slot vector. The fixed code ignores both
+      -- and computes raSize=10, retained=10 from the compactor itself.
+      aux <- mkAuxiliary HighRanksAreAccurate 999 3 (Vector.singleton compactor)
+      raSize aux `shouldBe` 10
+      U.length (raWeightedItems aux) `shouldBe` 10
+      Aux.getQuantile aux 0.5 (:<) `shouldSatisfy` (\q -> q >= 1 && q <= 10)
+    specify "mkAuxiliary handles empty compactor set" $ do
+      aux <- mkAuxiliary HighRanksAreAccurate 0 0 Vector.empty
+      raSize aux `shouldBe` 0
+      U.length (raWeightedItems aux) `shouldBe` 0
 
 checkMergeSortIn :: RankAccuracy -> Spec
 checkMergeSortIn ra = specify ("mergeSortIn works. hra=" ++ show ra) $ do

--- a/data-sketches/test/Spec.hs
+++ b/data-sketches/test/Spec.hs
@@ -11,18 +11,22 @@ import qualified CountMinSpec
 import qualified BugFixSpec
 import qualified CrossValidationSpec
 import System.Environment
-import Test.HSpec.JUnit
+import Test.Hspec.JUnit
+import Test.Hspec.JUnit.Config
 import Test.Hspec.Runner
+import qualified Data.Text as T
 
 main :: IO ()
-main = 
+main =
       getArgs
   >>= readConfig config
   >>= withArgs [] . runSpec specs
   >>= evaluateSummary
   where
-    config = defaultConfig 
-      { configFormat = Just $ junitFormat "test-results.xml" "data-sketches" 
+    config = defaultConfig
+      { configFormat = Just $ junitFormat $
+          setJUnitConfigOutputFile "test-results.xml" $
+            defaultJUnitConfig (T.pack "data-sketches")
       }
     specs = do
       describe "Auxiliary" AuxiliarySpec.spec


### PR DESCRIPTION
An async exception delivered mid-insert (e.g. warp killing a request
handler on client disconnect, while inside `withMVar … insert`) can
leave the sketch's cached totalN / retainedItems out of sync with the
actual compactor buffers; the next quantile() then threw
"invariant violated: lastWeight does not equal raSize". mkAuxiliary now
recomputes both the retained-item count and the total weight from the
compactors themselves, so the auxiliary is always self-consistent and
quantile() never throws on this path. Signature unchanged; the cached
parameters are accepted but ignored.

Also fixes the test driver for current hspec-junit-formatter
(Test.HSpec.JUnit → Test.Hspec.JUnit, junitFormat now takes a
JUnitConfig) and adds regression tests covering stale cache and
empty-compactor inputs.

Fixes: #2
